### PR TITLE
feat: Relay Explorer

### DIFF
--- a/src/components/RelayExplorer.tsx
+++ b/src/components/RelayExplorer.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { Radio, AlertTriangle, Loader2 } from "lucide-react";
+import { KindFilter } from "@/lib/relay-explorer";
+import { useRelayExplorer } from "@/components/relay-explorer/useRelayExplorer";
+import Nip11Panel from "@/components/relay-explorer/Nip11Panel";
+import LiveEventFeed from "@/components/relay-explorer/LiveEventFeed";
+import KindDistributionChart from "@/components/relay-explorer/KindDistributionChart";
+import ExplorerStats from "@/components/relay-explorer/ExplorerStats";
+import { cn } from "@/lib/utils";
+
+interface RelayExplorerProps {
+  relayUrl: string;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "connecting" || status === "idle") {
+    return (
+      <span className="flex items-center gap-1.5 text-metric-sm text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Connecting…
+      </span>
+    );
+  }
+  if (status === "connected") {
+    return (
+      <span className="flex items-center gap-1.5 text-metric-sm text-success">
+        <span className="h-2 w-2 rounded-full bg-success animate-live-pulse" />
+        Live
+      </span>
+    );
+  }
+  if (status === "error" || status === "closed") {
+    return (
+      <span className="flex items-center gap-1.5 text-metric-sm text-destructive">
+        <AlertTriangle className="h-3 w-3" />
+        {status === "error" ? "Connection error" : "Disconnected"}
+      </span>
+    );
+  }
+  return null;
+}
+
+export default function RelayExplorer({ relayUrl }: RelayExplorerProps) {
+  const { events, status, isPaused, togglePause } = useRelayExplorer(relayUrl);
+  const [filter, setFilter] = useState<KindFilter>("all");
+
+  return (
+    <div className="space-y-4">
+      {/* Section header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Radio
+            className={cn(
+              "h-4 w-4",
+              status === "connected" ? "text-success" : "text-muted-foreground"
+            )}
+          />
+          <h2 className="font-mono text-sm font-medium text-foreground">
+            Explorer
+          </h2>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      {/* NIP-11 Relay Info */}
+      <Nip11Panel relayUrl={relayUrl} />
+
+      {/* Stats summary */}
+      <ExplorerStats events={events} />
+
+      {/* Live event feed + kind distribution side by side on large screens */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
+        <div className="lg:col-span-3">
+          <LiveEventFeed
+            events={events}
+            isPaused={isPaused}
+            onTogglePause={togglePause}
+            filter={filter}
+            onFilterChange={setFilter}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <KindDistributionChart events={events} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/relay-explorer/ExplorerStats.tsx
+++ b/src/components/relay-explorer/ExplorerStats.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { ExplorerEvent, KIND_LABELS } from "@/lib/relay-explorer";
+
+interface ExplorerStatsProps {
+  events: ExplorerEvent[];
+}
+
+function StatItem({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <span className="text-metric-sm text-muted-foreground">{label}</span>
+      <div className="mt-1">
+        <span className="font-mono text-metric-lg tabular-nums text-foreground">
+          {value}
+        </span>
+        {sub && (
+          <span className="ml-1.5 text-metric-sm text-muted-foreground">
+            {sub}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ExplorerStats({ events }: ExplorerStatsProps) {
+  const stats = useMemo(() => {
+    if (events.length === 0) {
+      return { authors: 0, eventsPerMin: 0, topKind: null as string | null };
+    }
+
+    const authors = new Set(events.map((e) => e.pubkey)).size;
+
+    const now = Date.now();
+    const oneMinAgo = now - 60_000;
+    const recentCount = events.filter((e) => e.receivedAt >= oneMinAgo).length;
+
+    const kindCounts = new Map<number, number>();
+    for (const e of events) {
+      kindCounts.set(e.kind, (kindCounts.get(e.kind) ?? 0) + 1);
+    }
+    const topKindEntry = Array.from(kindCounts.entries()).sort(
+      (a, b) => b[1] - a[1]
+    )[0];
+    const topKind = topKindEntry
+      ? KIND_LABELS[topKindEntry[0]] ?? `Kind ${topKindEntry[0]}`
+      : null;
+
+    return { authors, eventsPerMin: recentCount, topKind };
+  }, [events]);
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <StatItem
+        label="TOTAL EVENTS"
+        value={events.length.toLocaleString()}
+      />
+      <StatItem
+        label="UNIQUE AUTHORS"
+        value={stats.authors.toLocaleString()}
+      />
+      <StatItem
+        label="EVENTS / MIN"
+        value={stats.eventsPerMin.toLocaleString()}
+        sub="last 60s"
+      />
+      <StatItem
+        label="TOP KIND"
+        value={stats.topKind ?? "—"}
+      />
+    </div>
+  );
+}

--- a/src/components/relay-explorer/KindDistributionChart.tsx
+++ b/src/components/relay-explorer/KindDistributionChart.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useId } from "react";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import { ExplorerEvent, KIND_LABELS } from "@/lib/relay-explorer";
+import { getCSSVar } from "@/contexts/ThemeContext";
+
+interface KindDistributionChartProps {
+  events: ExplorerEvent[];
+}
+
+const CHART_VARS = [
+  "--chart-1",
+  "--chart-2",
+  "--chart-3",
+  "--chart-4",
+  "--chart-5",
+  "--muted-foreground",
+  "--chart-1",
+  "--chart-3",
+] as const;
+
+function getKindLabel(kind: number): string {
+  return KIND_LABELS[kind] ?? `Kind ${kind}`;
+}
+
+export default function KindDistributionChart({
+  events,
+}: KindDistributionChartProps) {
+  const id = useId();
+
+  const chartData = useMemo(() => {
+    const counts = new Map<number, number>();
+    for (const e of events) {
+      counts.set(e.kind, (counts.get(e.kind) ?? 0) + 1);
+    }
+    const sorted = Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8);
+    const total = sorted.reduce((s, [, c]) => s + c, 0);
+    return sorted.map(([kind, count]) => ({
+      kind,
+      label: getKindLabel(kind),
+      count,
+      pct: total > 0 ? Math.round((count / total) * 100) : 0,
+    }));
+  }, [events]);
+
+  const colors = CHART_VARS.map((v) => `hsl(${getCSSVar(v)})`);
+  const borderColor = `hsl(${getCSSVar("--border")})`;
+  const cardColor = `hsl(${getCSSVar("--card")})`;
+  const mutedFg = `hsl(${getCSSVar("--muted-foreground")})`;
+
+  if (events.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-lg border border-border bg-card text-metric-sm text-muted-foreground">
+        Waiting for events…
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+        {/* Donut */}
+        <div className="shrink-0 h-40 w-40 mx-auto sm:mx-0">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius="55%"
+                outerRadius="85%"
+                dataKey="count"
+                strokeWidth={0}
+                paddingAngle={2}
+              >
+                {chartData.map((_, i) => (
+                  <Cell key={`${id}-cell-${i}`} fill={colors[i % colors.length]} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: cardColor,
+                  border: `1px solid ${borderColor}`,
+                  borderRadius: "4px",
+                  fontFamily: "JetBrains Mono",
+                  fontSize: "11px",
+                }}
+                labelStyle={{ color: mutedFg }}
+                formatter={(value: number, _name: string, entry: { payload?: { label?: string; pct?: number } }) => [
+                  `${value} (${entry.payload?.pct ?? 0}%)`,
+                  entry.payload?.label ?? "",
+                ]}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Legend */}
+        <div className="flex-1 space-y-1.5 min-w-0">
+          {chartData.map((item, i) => (
+            <div key={item.kind} className="flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                style={{ backgroundColor: colors[i % colors.length] }}
+              />
+              <span className="font-mono text-[11px] text-foreground truncate flex-1">
+                {item.label}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground tabular-nums shrink-0">
+                {item.count}
+              </span>
+              <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums w-8 text-right shrink-0">
+                {item.pct}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/relay-explorer/LiveEventFeed.tsx
+++ b/src/components/relay-explorer/LiveEventFeed.tsx
@@ -1,0 +1,209 @@
+import { useRef, useEffect } from "react";
+import {
+  User,
+  MessageSquare,
+  Users,
+  Heart,
+  Zap,
+  FileText,
+  ExternalLink,
+  Pause,
+  Play,
+} from "lucide-react";
+import {
+  ExplorerEvent,
+  KindFilter,
+  KIND_FILTER_KINDS,
+  KIND_LABELS,
+  getContentPreview,
+  relativeTime,
+  truncateNpub,
+  getNjumpUrl,
+} from "@/lib/relay-explorer";
+import { cn } from "@/lib/utils";
+
+const KIND_ICONS: Record<number, React.ElementType> = {
+  0: User,
+  1: MessageSquare,
+  3: Users,
+  7: Heart,
+  9735: Zap,
+  30023: FileText,
+};
+
+const KIND_COLORS: Record<number, string> = {
+  0: "text-blue-400",
+  1: "text-foreground",
+  3: "text-purple-400",
+  7: "text-pink-400",
+  9735: "text-yellow-400",
+  30023: "text-green-400",
+};
+
+const FILTER_TABS: { key: KindFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "notes", label: "Notes" },
+  { key: "articles", label: "Articles" },
+  { key: "zaps", label: "Zaps" },
+  { key: "reactions", label: "Reactions" },
+  { key: "profiles", label: "Profiles" },
+];
+
+interface LiveEventFeedProps {
+  events: ExplorerEvent[];
+  isPaused: boolean;
+  onTogglePause: () => void;
+  filter: KindFilter;
+  onFilterChange: (f: KindFilter) => void;
+}
+
+function EventCard({ event }: { event: ExplorerEvent }) {
+  const Icon = KIND_ICONS[event.kind] ?? MessageSquare;
+  const label = KIND_LABELS[event.kind] ?? `Kind ${event.kind}`;
+  const color = KIND_COLORS[event.kind] ?? "text-muted-foreground";
+  const preview = getContentPreview(event);
+  const npub = truncateNpub(event.pubkey);
+  const time = relativeTime(event.created_at);
+  const njumpUrl = getNjumpUrl(event);
+
+  return (
+    <div className="group flex items-start gap-3 px-3 py-2.5 border-b border-border/50 last:border-0 hover:bg-muted/20 transition-colors">
+      <div className={cn("mt-0.5 shrink-0", color)}>
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 mb-0.5">
+          <span className={cn("font-mono text-[11px] font-medium", color)}>
+            {label}
+          </span>
+          <span className="text-muted-foreground/60 text-[10px]">·</span>
+          <span className="font-mono text-[11px] text-muted-foreground truncate">
+            {npub}
+          </span>
+        </div>
+        <p className="text-metric-sm text-muted-foreground truncate leading-snug">
+          {preview}
+        </p>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
+          {time}
+        </span>
+        <a
+          href={njumpUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+          aria-label="View on njump.me"
+        >
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function LiveEventFeed({
+  events,
+  isPaused,
+  onTogglePause,
+  filter,
+  onFilterChange,
+}: LiveEventFeedProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevLengthRef = useRef(0);
+
+  const filteredEvents =
+    filter === "all"
+      ? events
+      : events.filter((e) => KIND_FILTER_KINDS[filter].includes(e.kind));
+
+  // Auto-scroll to top when new events arrive and not paused
+  useEffect(() => {
+    if (!isPaused && filteredEvents.length > prevLengthRef.current) {
+      scrollRef.current?.scrollTo({ top: 0 });
+    }
+    prevLengthRef.current = filteredEvents.length;
+  }, [filteredEvents.length, isPaused]);
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <div className="flex items-center gap-1 overflow-x-auto scrollbar-none">
+          {FILTER_TABS.map((tab) => {
+            const count =
+              tab.key === "all"
+                ? events.length
+                : events.filter((e) =>
+                    KIND_FILTER_KINDS[tab.key].includes(e.kind)
+                  ).length;
+            return (
+              <button
+                key={tab.key}
+                onClick={() => onFilterChange(tab.key)}
+                className={cn(
+                  "shrink-0 px-2.5 py-1 rounded-md font-mono text-[11px] transition-colors",
+                  filter === tab.key
+                    ? "bg-primary/15 text-primary font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                )}
+              >
+                {tab.label}
+                {count > 0 && (
+                  <span
+                    className={cn(
+                      "ml-1.5 tabular-nums",
+                      filter === tab.key
+                        ? "text-primary/70"
+                        : "text-muted-foreground/50"
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          onClick={onTogglePause}
+          className={cn(
+            "shrink-0 ml-2 flex items-center gap-1.5 rounded-md px-2.5 py-1 font-mono text-[11px] transition-colors",
+            isPaused
+              ? "bg-warning/15 text-warning hover:bg-warning/25"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/40"
+          )}
+          title={isPaused ? "Resume auto-scroll" : "Pause auto-scroll"}
+        >
+          {isPaused ? (
+            <>
+              <Play className="h-3 w-3" /> Resume
+            </>
+          ) : (
+            <>
+              <Pause className="h-3 w-3" /> Pause
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Event list */}
+      <div
+        ref={scrollRef}
+        className="h-80 overflow-y-auto overflow-x-hidden"
+      >
+        {filteredEvents.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-metric-sm text-muted-foreground">
+            {events.length === 0 ? "Waiting for events…" : "No events match this filter"}
+          </div>
+        ) : (
+          filteredEvents.map((event) => (
+            <EventCard key={`${event.id}-${event.receivedAt}`} event={event} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/relay-explorer/Nip11Panel.tsx
+++ b/src/components/relay-explorer/Nip11Panel.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, Server } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { fetchRelayInfo } from "@/lib/relay-explorer";
+import { cn } from "@/lib/utils";
+import { npubEncode } from "nostr-tools/nip19";
+
+interface Nip11PanelProps {
+  relayUrl: string;
+}
+
+function truncatePubkey(hex: string): string {
+  try {
+    const npub = npubEncode(hex);
+    return npub.slice(0, 12) + "…" + npub.slice(-6);
+  } catch {
+    return hex.slice(0, 16) + "…";
+  }
+}
+
+function LimitRow({ label, value }: { label: string; value: string | number | boolean | undefined }) {
+  if (value === undefined || value === null) return null;
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-metric-sm text-muted-foreground">{label}</span>
+      <span className="font-mono text-metric-sm text-foreground tabular-nums">
+        {typeof value === "boolean" ? (value ? "yes" : "no") : String(value)}
+      </span>
+    </div>
+  );
+}
+
+export default function Nip11Panel({ relayUrl }: Nip11PanelProps) {
+  const [open, setOpen] = useState(true);
+
+  const { data: info, isLoading, error } = useQuery({
+    queryKey: ["relay-nip11", relayUrl],
+    queryFn: () => fetchRelayInfo(relayUrl),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  const hasLimitations =
+    info?.limitation &&
+    Object.values(info.limitation).some((v) => v !== undefined && v !== null);
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between px-4 py-3 hover:bg-muted/30 transition-colors rounded-lg"
+      >
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 text-muted-foreground" />
+          <span className="font-mono text-sm font-medium text-foreground">
+            Relay Info
+          </span>
+          {info?.name && (
+            <span className="text-metric-sm text-muted-foreground">
+              — {info.name}
+            </span>
+          )}
+        </div>
+        {open ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+        )}
+      </button>
+
+      {open && (
+        <div className="border-t border-border px-4 pb-4 pt-3 space-y-4">
+          {isLoading && (
+            <div className="flex items-center gap-2 text-metric-sm text-muted-foreground">
+              <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              Fetching relay info…
+            </div>
+          )}
+
+          {error && (
+            <p className="text-metric-sm text-destructive">
+              Could not fetch relay info — relay may not support NIP-11.
+            </p>
+          )}
+
+          {info && (
+            <div className="space-y-4">
+              {/* Name + Description */}
+              {(info.name || info.description) && (
+                <div className="space-y-1">
+                  {info.name && (
+                    <p className="font-mono text-sm font-semibold text-foreground">
+                      {info.name}
+                    </p>
+                  )}
+                  {info.description && (
+                    <p className="text-metric-sm text-muted-foreground leading-relaxed">
+                      {info.description}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* Metadata grid */}
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {info.pubkey && (
+                  <div className="rounded-md border border-border bg-muted/20 px-3 py-2">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      Pubkey
+                    </span>
+                    <p className="font-mono text-metric-sm text-foreground mt-0.5 break-all">
+                      {truncatePubkey(info.pubkey)}
+                    </p>
+                  </div>
+                )}
+                {info.contact && (
+                  <div className="rounded-md border border-border bg-muted/20 px-3 py-2">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      Contact
+                    </span>
+                    <p className="font-mono text-metric-sm text-foreground mt-0.5 truncate">
+                      {info.contact}
+                    </p>
+                  </div>
+                )}
+                {info.software && (
+                  <div className="rounded-md border border-border bg-muted/20 px-3 py-2">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      Software
+                    </span>
+                    <p className="font-mono text-metric-sm text-foreground mt-0.5 truncate">
+                      {info.software}
+                      {info.version && (
+                        <span className="ml-1 text-muted-foreground">
+                          v{info.version}
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Supported NIPs */}
+              {info.supported_nips && info.supported_nips.length > 0 && (
+                <div className="space-y-1.5">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Supported NIPs
+                  </span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {info.supported_nips.map((nip) => (
+                      <Badge
+                        key={nip}
+                        variant="outline"
+                        className={cn(
+                          "font-mono text-xs px-2 py-0.5",
+                          [1, 4, 9, 11, 17, 42, 45].includes(nip)
+                            ? "border-primary/40 text-primary"
+                            : "text-muted-foreground"
+                        )}
+                      >
+                        NIP-{nip}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Limitations */}
+              {hasLimitations && (
+                <div className="space-y-0.5">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Limitations
+                  </span>
+                  <div className="rounded-md border border-border divide-y divide-border">
+                    <div className="px-3 py-0.5">
+                      <LimitRow label="Max message length" value={info.limitation?.max_message_length} />
+                      <LimitRow label="Max subscriptions" value={info.limitation?.max_subscriptions} />
+                      <LimitRow label="Max filters" value={info.limitation?.max_filters} />
+                      <LimitRow label="Max limit" value={info.limitation?.max_limit} />
+                      <LimitRow label="Max event tags" value={info.limitation?.max_event_tags} />
+                      <LimitRow label="Max content length" value={info.limitation?.max_content_length} />
+                      <LimitRow label="Min PoW difficulty" value={info.limitation?.min_pow_difficulty} />
+                      <LimitRow label="Auth required" value={info.limitation?.auth_required} />
+                      <LimitRow label="Payment required" value={info.limitation?.payment_required} />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/relay-explorer/useRelayExplorer.ts
+++ b/src/components/relay-explorer/useRelayExplorer.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  ExplorerEvent,
+  WsStatus,
+  connectRelayExplorer,
+} from "@/lib/relay-explorer";
+
+const MAX_EVENTS = 200;
+
+export function useRelayExplorer(relayUrl: string) {
+  const [events, setEvents] = useState<ExplorerEvent[]>([]);
+  const [status, setStatus] = useState<WsStatus | "idle">("idle");
+  const [isPaused, setIsPaused] = useState(false);
+  const isPausedRef = useRef(false);
+
+  isPausedRef.current = isPaused;
+
+  const handleEvent = useCallback((event: ExplorerEvent) => {
+    if (isPausedRef.current) return;
+    setEvents((prev) => [event, ...prev].slice(0, MAX_EVENTS));
+  }, []);
+
+  useEffect(() => {
+    setEvents([]);
+    setStatus("idle");
+
+    const cleanup = connectRelayExplorer(relayUrl, handleEvent, setStatus);
+    return cleanup;
+  }, [relayUrl, handleEvent]);
+
+  const togglePause = useCallback(() => setIsPaused((p) => !p), []);
+
+  return { events, status, isPaused, togglePause };
+}

--- a/src/lib/relay-explorer.ts
+++ b/src/lib/relay-explorer.ts
@@ -1,0 +1,203 @@
+import { npubEncode, noteEncode, neventEncode } from "nostr-tools/nip19";
+
+export interface RelayInfo {
+  name?: string;
+  description?: string;
+  pubkey?: string;
+  contact?: string;
+  supported_nips?: number[];
+  software?: string;
+  version?: string;
+  limitation?: {
+    max_message_length?: number;
+    max_subscriptions?: number;
+    max_filters?: number;
+    max_limit?: number;
+    max_event_tags?: number;
+    max_content_length?: number;
+    min_pow_difficulty?: number;
+    auth_required?: boolean;
+    payment_required?: boolean;
+  };
+}
+
+export interface ExplorerEvent {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  receivedAt: number;
+}
+
+export type KindFilter =
+  | "all"
+  | "notes"
+  | "articles"
+  | "zaps"
+  | "reactions"
+  | "profiles";
+
+export const KIND_LABELS: Record<number, string> = {
+  0: "Profile",
+  1: "Note",
+  3: "Contacts",
+  7: "Reaction",
+  9735: "Zap",
+  30023: "Article",
+};
+
+export const KIND_FILTER_KINDS: Record<KindFilter, number[]> = {
+  all: [],
+  notes: [1],
+  articles: [30023],
+  zaps: [9735],
+  reactions: [7],
+  profiles: [0],
+};
+
+export async function fetchRelayInfo(wssUrl: string): Promise<RelayInfo> {
+  const httpUrl = wssUrl
+    .replace(/^wss:\/\//, "https://")
+    .replace(/^ws:\/\//, "http://");
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8000);
+  try {
+    const res = await fetch(httpUrl, {
+      headers: { Accept: "application/nostr+json" },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as RelayInfo;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export function getContentPreview(event: ExplorerEvent): string {
+  switch (event.kind) {
+    case 0: {
+      try {
+        const p = JSON.parse(event.content) as Record<string, string>;
+        return p.name || p.display_name || "Profile update";
+      } catch {
+        return "Profile update";
+      }
+    }
+    case 1:
+      return event.content.slice(0, 100) || "(empty note)";
+    case 3: {
+      const n = event.tags.filter((t) => t[0] === "p").length;
+      return `${n} contact${n !== 1 ? "s" : ""}`;
+    }
+    case 7:
+      return `"${event.content || "+"}" reaction`;
+    case 9735:
+      return "Zap receipt";
+    case 30023: {
+      const titleTag = event.tags.find((t) => t[0] === "title");
+      return titleTag?.[1] || event.content.slice(0, 100) || "Article";
+    }
+    default:
+      return event.content.slice(0, 100) || "(no content)";
+  }
+}
+
+export function relativeTime(unixSecs: number): string {
+  const diff = Math.floor(Date.now() / 1000 - unixSecs);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export function truncateNpub(hexPubkey: string): string {
+  try {
+    const npub = npubEncode(hexPubkey);
+    return npub.slice(0, 8) + ":" + npub.slice(-4);
+  } catch {
+    return hexPubkey.slice(0, 8) + ":" + hexPubkey.slice(-4);
+  }
+}
+
+export function getNjumpUrl(event: ExplorerEvent): string {
+  try {
+    if (event.kind === 1) {
+      return `https://njump.me/${noteEncode(event.id)}`;
+    }
+    return `https://njump.me/${neventEncode({
+      id: event.id,
+      author: event.pubkey,
+      kind: event.kind,
+    })}`;
+  } catch {
+    return `https://njump.me/${event.id}`;
+  }
+}
+
+export type WsStatus = "connecting" | "connected" | "closed" | "error";
+
+export function connectRelayExplorer(
+  wssUrl: string,
+  onEvent: (event: ExplorerEvent) => void,
+  onStatus: (status: WsStatus) => void
+): () => void {
+  const subId = Math.random().toString(36).slice(2, 10);
+  let ws: WebSocket | null = null;
+  let closed = false;
+
+  onStatus("connecting");
+
+  try {
+    ws = new WebSocket(wssUrl);
+  } catch {
+    onStatus("error");
+    return () => {};
+  }
+
+  ws.onopen = () => {
+    if (closed) return;
+    onStatus("connected");
+    ws!.send(
+      JSON.stringify([
+        "REQ",
+        subId,
+        { limit: 50, kinds: [0, 1, 3, 7, 9735, 30023] },
+      ])
+    );
+  };
+
+  ws.onmessage = (e: MessageEvent) => {
+    if (closed) return;
+    try {
+      const msg = JSON.parse(e.data as string) as unknown[];
+      if (msg[0] === "EVENT" && msg[2]) {
+        const ev = msg[2] as Omit<ExplorerEvent, "receivedAt">;
+        onEvent({ ...ev, receivedAt: Date.now() });
+      }
+    } catch {
+      // ignore parse errors
+    }
+  };
+
+  ws.onclose = () => {
+    if (!closed) onStatus("closed");
+  };
+
+  ws.onerror = () => {
+    if (!closed) onStatus("error");
+  };
+
+  return () => {
+    closed = true;
+    try {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(["CLOSE", subId]));
+      }
+      ws?.close();
+    } catch {
+      // ignore
+    }
+  };
+}

--- a/src/pages/RelayDetailPage.tsx
+++ b/src/pages/RelayDetailPage.tsx
@@ -26,6 +26,7 @@ import TimeseriesChart from "@/components/TimeseriesChart";
 import StatsGrid from "@/components/StatsGrid";
 import IncidentsTimeline from "@/components/IncidentsTimeline";
 import { ArrowLeft, Copy, Check } from "lucide-react";
+import RelayExplorer from "@/components/RelayExplorer";
 import {
   Tooltip,
   TooltipContent,
@@ -325,6 +326,11 @@ export default function RelayDetailPage() {
         </h2>
         <TimeseriesChart data={uptimeTs || []} />
         <StatsGrid stats={toStats(upMetric)} />
+      </section>
+
+      {/* Explorer */}
+      <section className="space-y-3">
+        <RelayExplorer relayUrl={relay.url} />
       </section>
     </div>
   );


### PR DESCRIPTION
## Relay Explorer

Adds an Explorer section to the relay detail page — analytics + content previews for any monitored relay.

### What's new
- **NIP-11 Relay Info** — collapsible panel showing relay name, description, supported NIPs (as badges), software/version, contact, and limitations
- **Live Event Feed** — real-time WebSocket stream of events with kind filter tabs (All | Notes | Articles | Zaps | Reactions | Profiles), pause/resume, and njump.me click-through links
- **Event Kind Distribution** — recharts donut chart showing top 8 event kinds with counts and percentages
- **Stats Grid** — total events, unique authors, events/min, most active kind

### Architecture
- All client-side — no Supabase or backend changes
- WebSocket connection managed via `useRelayExplorer` hook with proper cleanup on unmount
- NIP-11 fetch via TanStack Query with 5min stale time
- 200-event buffer to keep memory bounded

### Files
- `src/components/RelayExplorer.tsx` — main container
- `src/lib/relay-explorer.ts` — WS logic + NIP-11 + event utilities
- `src/components/relay-explorer/` — sub-components (Nip11Panel, LiveEventFeed, KindDistributionChart, ExplorerStats, useRelayExplorer)
- `src/pages/RelayDetailPage.tsx` — integration point